### PR TITLE
Add optional timeout parameter to await*() methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Add optional `$timeout` parameter to `await*()` methods.
+
 ## 0.1.1 (2015-04-05)
 
 * `run()` the loop instead of making it `tick()`.

--- a/src/Blocker.php
+++ b/src/Blocker.php
@@ -53,15 +53,7 @@ class Blocker
         $onComplete = $this->getOnCompleteFn($resolution, $wait, array($promise), $timeout);
         $promise->then($onComplete, $onComplete);
 
-        while ($wait) {
-            $this->loop->run();
-        }
-
-        if ($resolution instanceof Exception) {
-            throw $resolution;
-        }
-
-        return $resolution;
+        return $this->awaitResolution($wait, $resolution);
     }
 
     /**
@@ -103,15 +95,7 @@ class Blocker
             );
         }
 
-        while ($wait) {
-            $this->loop->run();
-        }
-
-        if ($resolution instanceof Exception) {
-            throw $resolution;
-        }
-
-        return $resolution;
+        return $this->awaitResolution($wait, $resolution);
     }
 
     /**
@@ -158,6 +142,11 @@ class Blocker
             );
         }
 
+        return $this->awaitResolution($wait, $resolution);
+    }
+
+    private function awaitResolution(&$wait, &$resolution)
+    {
         while ($wait) {
             $this->loop->run();
         }

--- a/src/Blocker.php
+++ b/src/Blocker.php
@@ -42,7 +42,8 @@ class Blocker
      * @param PromiseInterface $promise
      * @param double $timeout maximum time to wait in seconds
      * @return mixed returns whatever the promise resolves to
-     * @throws Exception when the promise is rejected or times out
+     * @throws Exception when the promise is rejected
+     * @throws TimeoutException when the timeout is reached and the promise is not resolved
      */
     public function awaitOne(PromiseInterface $promise, $timeout = null)
     {
@@ -97,7 +98,8 @@ class Blocker
      * @param array $promises
      * @param double $timeout maximum time to wait in seconds
      * @return mixed returns whatever the first promise resolves to
-     * @throws Exception if ALL promises are rejected or ALL promises time out
+     * @throws Exception if ALL promises are rejected
+     * @throws TimeoutException if the timeout is reached and NO promise is resolved
      */
     public function awaitRace(array $promises, $timeout = null)
     {
@@ -181,7 +183,8 @@ class Blocker
      * @param array $promises
      * @param double $timeout maximum time to wait in seconds
      * @return array returns an array with whatever each promise resolves to
-     * @throws Exception when ANY promise is rejected or ANY promise times out
+     * @throws Exception when ANY promise is rejected
+     * @throws TimeoutException if the timeout is reached and ANY promise is not resolved
      */
     public function awaitAll(array $promises, $timeout = null)
     {

--- a/src/Blocker.php
+++ b/src/Blocker.php
@@ -70,7 +70,7 @@ class Blocker
                 if (!$wait) {
                     return;
                 }
-                $exception = new RuntimeException('The promise could not resolve in the allowed time');
+                $exception = new TimeoutException('The promise could not resolve in the allowed time');
                 $wait = false;
                 $loop->stop();
             });
@@ -148,7 +148,7 @@ class Blocker
                 if (!$wait) {
                     return;
                 }
-                $exception = new RuntimeException('No promise could resolve in the allowed time');
+                $exception = new TimeoutException('No promise could resolve in the allowed time');
                 $wait = 0;
                 $loop->stop();
             });
@@ -228,7 +228,7 @@ class Blocker
                 if (!$wait) {
                     return;
                 }
-                $exception = new RuntimeException('Not all promises could resolve in the allowed time');
+                $exception = new TimeoutException('Not all promises could resolve in the allowed time');
                 $wait = 0;
                 $loop->stop();
             });

--- a/src/Blocker.php
+++ b/src/Blocker.php
@@ -67,6 +67,9 @@ class Blocker
 
         if ($timeout) {
             $loop->addTimer($timeout, function () use (&$exception, &$wait, $loop) {
+                if (!$wait) {
+                    return;
+                }
                 $exception = new RuntimeException('The promise could not resolve in the allowed time');
                 $wait = false;
                 $loop->stop();
@@ -142,6 +145,9 @@ class Blocker
 
         if ($timeout) {
             $loop->addTimer($timeout, function () use (&$exception, &$wait, $loop) {
+                if (!$wait) {
+                    return;
+                }
                 $exception = new RuntimeException('No promise could resolve in the allowed time');
                 $wait = 0;
                 $loop->stop();
@@ -219,6 +225,9 @@ class Blocker
 
         if ($timeout) {
             $loop->addTimer($timeout, function () use (&$exception, &$wait, $loop) {
+                if (!$wait) {
+                    return;
+                }
                 $exception = new RuntimeException('Not all promises could resolve in the allowed time');
                 $wait = 0;
                 $loop->stop();

--- a/src/Blocker.php
+++ b/src/Blocker.php
@@ -5,7 +5,6 @@ namespace Clue\React\Block;
 use React\EventLoop\LoopInterface;
 use React\Promise\PromiseInterface;
 use React\Promise\CancellablePromiseInterface;
-use RuntimeException;
 use UnderflowException;
 use Exception;
 

--- a/src/TimeoutException.php
+++ b/src/TimeoutException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Clue\React\Block;
+
+use RuntimeException;
+
+class TimeoutException extends RuntimeException
+{
+
+}

--- a/tests/BlockerTest.php
+++ b/tests/BlockerTest.php
@@ -5,6 +5,8 @@ use React\Promise\Deferred;
 
 class BlockerTest extends TestCase
 {
+    const TIMEOUT_EXCEPTION_CLASS = 'Clue\React\Block\TimeoutException';
+
     private $loop;
     private $block;
 
@@ -50,7 +52,7 @@ class BlockerTest extends TestCase
     {
         $promise = $this->createPromiseResolved(2, 0.02);
 
-        $this->setExpectedException('RuntimeException', 'The promise could not resolve in the allowed time');
+        $this->setExpectedException(self::TIMEOUT_EXCEPTION_CLASS);
         $this->block->awaitOne($promise, 0.01);
     }
 
@@ -148,7 +150,7 @@ class BlockerTest extends TestCase
             $this->createPromiseResolved(3, 0.03),
         );
 
-        $this->setExpectedException('RuntimeException', 'No promise could resolve in the allowed time');
+        $this->setExpectedException(self::TIMEOUT_EXCEPTION_CLASS);
         $this->block->awaitRace($all, 0.01);
     }
 
@@ -221,7 +223,7 @@ class BlockerTest extends TestCase
             $this->createPromiseResolved(3, 0.01),
         );
 
-        $this->setExpectedException('RuntimeException', 'Not all promises could resolve in the allowed time');
+        $this->setExpectedException(self::TIMEOUT_EXCEPTION_CLASS);
         $this->block->awaitAll($all, 0.02);
     }
 

--- a/tests/BlockerTest.php
+++ b/tests/BlockerTest.php
@@ -121,7 +121,7 @@ class BlockerTest extends TestCase
             $this->createPromiseResolved(3, 0.03),
         );
 
-        $this->assertEquals(2, $this->block->awaitRace($all));
+        $this->assertEquals(2, $this->block->awaitRace($all, 0.2));
     }
 
     public function testAwaitRaceAllTimedOut()


### PR DESCRIPTION
Calling `await*()` with no timeout is scary. I think that in almost all cases, when we wait for something we don't want to potentially wait forever. While clients of this library could handle this themselves, it's much easier to add it to this library directly.

Regarding the implementation: it might make sense to have a `TimeoutException` class to make it easier for clients to differentiate between rejected promises and timeouts.

It's totally cool if you don't want to merge this!