### PR TITLE
Rename awaitOne() to await()

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ $blocker = new Blocker($loop);
 
 The `wait($seconds)` method can be used to wait/sleep for $time seconds.
 
-#### awaitOne()
+#### await()
 
-The `awaitOne(PromiseInterface $promise)` method can be used to block waiting for the given $promise to resolve.
+The `await(PromiseInterface $promise)` method can be used to block waiting for the given $promise to resolve.
 
 #### awaitRace()
 

--- a/src/Blocker.php
+++ b/src/Blocker.php
@@ -43,7 +43,7 @@ class Blocker
      * @return mixed returns whatever the promise resolves to
      * @throws Exception when the promise is rejected
      */
-    public function awaitOne(PromiseInterface $promise)
+    public function await(PromiseInterface $promise)
     {
         $wait = true;
         $resolved = null;

--- a/tests/BlockerTest.php
+++ b/tests/BlockerTest.php
@@ -28,14 +28,14 @@ class BlockerTest extends TestCase
         $promise = $this->createPromiseRejected(new Exception('test'));
 
         $this->setExpectedException('Exception', 'test');
-        $this->block->awaitOne($promise);
+        $this->block->await($promise);
     }
 
     public function testAwaitOneResolved()
     {
         $promise = $this->createPromiseResolved(2);
 
-        $this->assertEquals(2, $this->block->awaitOne($promise));
+        $this->assertEquals(2, $this->block->await($promise));
     }
 
     public function testAwaitOneInterrupted()
@@ -43,7 +43,7 @@ class BlockerTest extends TestCase
         $promise = $this->createPromiseResolved(2, 0.02);
         $this->createTimerInterrupt(0.01);
 
-        $this->assertEquals(2, $this->block->awaitOne($promise));
+        $this->assertEquals(2, $this->block->await($promise));
     }
 
     /**


### PR DESCRIPTION
This is done in order to emphasize this is the underlying operation for
all other functions operating on promise collections.