### PR TITLE
Allow waiting inside a loop by ticking instead of running the loop

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -56,17 +56,15 @@ function await(PromiseInterface $promise, LoopInterface $loop, $timeout = null)
         function ($c) use (&$resolved, &$wait, $loop) {
             $resolved = $c;
             $wait = false;
-            $loop->stop();
         },
         function ($error) use (&$exception, &$wait, $loop) {
             $exception = $error;
             $wait = false;
-            $loop->stop();
         }
     );
 
     while ($wait) {
-        $loop->run();
+        $loop->tick();
     }
 
     if ($exception !== null) {


### PR DESCRIPTION
I needed to wait for a promise while already within a loop. Because the await() function calls $loop->stop(), the loop I was already in stopped.

I removed $loop->stop() and instead of $loop->run() I now call $loop->tick(). This has resolved my problem. The unittests are still working as well.

Please let me know about any problems with this approach, I will try to resolve them.