### PR TITLE
Forward compatibility with future EventLoop v1.0 and v0.5 and cap small timeout values for legacy EventLoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ The `sleep($seconds, LoopInterface $loop)` method can be used to wait/sleep for 
 Block\sleep(1.5, $loop);
 ```
 
+The $time value will be used as a timer for the loop so that it keeps running
+until the timeout triggers.
+This implies that if you pass a really small (or negative) value, it will still
+start a timer and will thus trigger at the earliest possible time in the future.
+
 While this may look similar to PHP's [`sleep()`](http://php.net/sleep) function,
 it's actual way more powerful:
 Instead of making the whole process sleep and handing over control to your operating system,
@@ -135,6 +140,8 @@ potentially wait/block forever until the promise is settled.
 
 If a $timeout is given and the promise is still pending once the timeout
 triggers, this will `cancel()` the promise and throw a `TimeoutException`.
+This implies that if you pass a really small (or negative) value, it will still
+start a timer and will thus trigger at the earliest possible time in the future.
 
 #### awaitAny()
 
@@ -162,6 +169,8 @@ potentially wait/block forever until the last promise is settled.
 
 If a $timeout is given and either promise is still pending once the timeout
 triggers, this will `cancel()` all pending promises and throw a `TimeoutException`.
+This implies that if you pass a really small (or negative) value, it will still
+start a timer and will thus trigger at the earliest possible time in the future.
 
 #### awaitAll()
 
@@ -191,6 +200,8 @@ potentially wait/block forever until the last promise is settled.
 
 If a $timeout is given and either promise is still pending once the timeout
 triggers, this will `cancel()` all pending promises and throw a `TimeoutException`.
+This implies that if you pass a really small (or negative) value, it will still
+start a timer and will thus trigger at the earliest possible time in the future.
 
 ## Install
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
     	"php": ">=5.3",
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
+        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5",
         "react/promise": "~2.1|~1.2",
         "react/promise-timer": "~1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
     	"php": ">=5.3",
-        "react/event-loop": "0.4.*|0.3.*",
+        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
         "react/promise": "~2.1|~1.2",
         "react/promise-timer": "~1.0"
     },

--- a/src/functions.php
+++ b/src/functions.php
@@ -14,6 +14,11 @@ use React\Promise\Timer\TimeoutException;
 /**
  * wait/sleep for $time seconds
  *
+ * The $time value will be used as a timer for the loop so that it keeps running
+ * until the timeout triggers.
+ * This implies that if you pass a really small (or negative) value, it will still
+ * start a timer and will thus trigger at the earliest possible time in the future.
+ *
  * @param float $time
  * @param LoopInterface $loop
  */
@@ -34,6 +39,8 @@ function sleep($time, LoopInterface $loop)
  *
  * If a $timeout is given and the promise is still pending once the timeout
  * triggers, this will cancel() the promise and throw a `TimeoutException`.
+ * This implies that if you pass a really small (or negative) value, it will still
+ * start a timer and will thus trigger at the earliest possible time in the future.
  *
  * @param PromiseInterface $promise
  * @param LoopInterface    $loop
@@ -89,6 +96,8 @@ function await(PromiseInterface $promise, LoopInterface $loop, $timeout = null)
  *
  * If a $timeout is given and either promise is still pending once the timeout
  * triggers, this will cancel() all pending promises and throw a `TimeoutException`.
+ * This implies that if you pass a really small (or negative) value, it will still
+ * start a timer and will thus trigger at the earliest possible time in the future.
  *
  * @param array         $promises
  * @param LoopInterface $loop
@@ -145,6 +154,8 @@ function awaitAny(array $promises, LoopInterface $loop, $timeout = null)
  *
  * If a $timeout is given and either promise is still pending once the timeout
  * triggers, this will cancel() all pending promises and throw a `TimeoutException`.
+ * This implies that if you pass a really small (or negative) value, it will still
+ * start a timer and will thus trigger at the earliest possible time in the future.
  *
  * @param array         $promises
  * @param LoopInterface $loop

--- a/tests/FunctionSleepTest.php
+++ b/tests/FunctionSleepTest.php
@@ -12,4 +12,13 @@ class FunctionSleepTest extends TestCase
 
         $this->assertEquals(0.2, $time, '', 0.1);
     }
+
+    public function testSleepSmallTimerWillBeCappedReasonably()
+    {
+        $time = microtime(true);
+        Block\sleep(0.0000001, $this->loop);
+        $time = microtime(true) - $time;
+
+        $this->assertEquals(0.1, $time, '', 0.1);
+    }
 }


### PR DESCRIPTION
Refs https://github.com/reactphp/event-loop/pull/47 and https://github.com/reactphp/promise-timer/pull/23