### PR TITLE
Improve error reporting by appending previous message for `Throwable`s

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -117,11 +117,15 @@ function await(PromiseInterface $promise, LoopInterface $loop, $timeout = null)
     }
 
     if ($rejected) {
-        if (!$exception instanceof \Exception) {
+        if (!$exception instanceof \Exception && !$exception instanceof \Throwable) {
             $exception = new \UnexpectedValueException(
-                'Promise rejected with unexpected value of type ' . (is_object($exception) ? get_class($exception) : gettype($exception)),
-                0,
-                $exception instanceof \Throwable ? $exception : null
+                'Promise rejected with unexpected value of type ' . (is_object($exception) ? get_class($exception) : gettype($exception))
+            );
+        } elseif (!$exception instanceof \Exception) {
+            $exception = new \UnexpectedValueException(
+                'Promise rejected with unexpected ' . get_class($exception) . ': ' . $exception->getMessage(),
+                $exception->getCode(),
+                $exception
             );
         }
 

--- a/tests/FunctionAwaitTest.php
+++ b/tests/FunctionAwaitTest.php
@@ -37,15 +37,17 @@ class FunctionAwaitTest extends TestCase
      */
     public function testAwaitOneRejectedWithPhp7ErrorWillWrapInUnexpectedValueExceptionWithPrevious()
     {
-        $promise = Promise\reject(new \Error('Test'));
+        $promise = Promise\reject(new \Error('Test', 42));
 
         try {
             Block\await($promise, $this->loop);
             $this->fail();
         } catch (\UnexpectedValueException $e) {
-            $this->assertEquals('Promise rejected with unexpected value of type Error', $e->getMessage());
+            $this->assertEquals('Promise rejected with unexpected Error: Test', $e->getMessage());
+            $this->assertEquals(42, $e->getCode());
             $this->assertInstanceOf('Throwable', $e->getPrevious());
             $this->assertEquals('Test', $e->getPrevious()->getMessage());
+            $this->assertEquals(42, $e->getPrevious()->getCode());
         }
     }
 


### PR DESCRIPTION
This changeset improves error reporting by appending previous exception messages for `Throwable`s (PHP 7+). This improves DX by making it easier to see the underlying error causes without having to check the previous exception via `$e->getPrevious()`.

Ideally, this would just throw the `Throwable` without wrapping this in an `UnexpectedValueException`, but this would constitute a BC break. Appending the original type and message to the `UnexpectedValueException` at least makes it more obvious to see the underlying error condition without introducing a BC break.

Supersedes / closes #52 
Supersedes / closes #56
Builds on top of #7/#27/#42
Refs https://github.com/reactphp/promise-stream/pull/26, https://github.com/friends-of-reactphp/mysql/pull/141 and others