### PR TITLE
Simplify usage by supporting new default loop

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
     },
     "require": {
         "php": ">=5.3",
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5",
+        "react/event-loop": "^1.2",
         "react/promise": "^2.7 || ^1.2.1",
         "react/promise-timer": "^1.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35",
-        "react/http": "^1.0"
+        "react/http": "^1.4"
     }
 }

--- a/examples/01-await.php
+++ b/examples/01-await.php
@@ -9,18 +9,15 @@ require __DIR__ . '/../vendor/autoload.php';
  */
 function requestHttp($url)
 {
-    // use a unique event loop instance for this operation
-    $loop = React\EventLoop\Factory::create();
-
     // This example uses an HTTP client
-    $browser = new React\Http\Browser($loop);
+    $browser = new React\Http\Browser();
 
     // set up one request
     $promise = $browser->get($url);
 
     try {
         // keep the loop running (i.e. block) until the response arrives
-        $result = Clue\React\Block\await($promise, $loop);
+        $result = Clue\React\Block\await($promise);
 
         // promise successfully fulfilled with $result
         return $result;

--- a/examples/02-await-any.php
+++ b/examples/02-await-any.php
@@ -10,11 +10,8 @@ require __DIR__ . '/../vendor/autoload.php';
  */
 function requestHttpFastestOfMultiple($url1, $url2)
 {
-    // use a unique event loop instance for all parallel operations
-    $loop = React\EventLoop\Factory::create();
-
     // This example uses an HTTP client
-    $browser = new React\Http\Browser($loop);
+    $browser = new React\Http\Browser();
 
     // set up two parallel requests
     $promises = array(
@@ -24,7 +21,7 @@ function requestHttpFastestOfMultiple($url1, $url2)
 
     try {
         // keep the loop running (i.e. block) until the first response arrives
-        $fasterResponse = Clue\React\Block\awaitAny($promises, $loop);
+        $fasterResponse = Clue\React\Block\awaitAny($promises);
 
         // promise successfully fulfilled with $fasterResponse
         return $fasterResponse;

--- a/examples/03-await-all.php
+++ b/examples/03-await-all.php
@@ -10,11 +10,8 @@ require __DIR__ . '/../vendor/autoload.php';
  */
 function requestHttpMultiple($url1, $url2)
 {
-    // use a unique event loop instance for all parallel operations
-    $loop = React\EventLoop\Factory::create();
-
     // This example uses an HTTP client
-    $browser = new React\Http\Browser($loop);
+    $browser = new React\Http\Browser();
 
     // set up two parallel requests
     $promises = array(
@@ -24,7 +21,7 @@ function requestHttpMultiple($url1, $url2)
 
     try {
         // keep the loop running (i.e. block) until all responses arrive
-        $allResults = Clue\React\Block\awaitAll($promises, $loop);
+        $allResults = Clue\React\Block\awaitAll($promises);
 
         // promise successfully fulfilled with $allResults
         return $allResults;

--- a/src/functions.php
+++ b/src/functions.php
@@ -2,14 +2,15 @@
 
 namespace Clue\React\Block;
 
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
-use React\Promise\PromiseInterface;
-use React\Promise\CancellablePromiseInterface;
-use UnderflowException;
-use Exception;
 use React\Promise;
+use React\Promise\CancellablePromiseInterface;
+use React\Promise\PromiseInterface;
 use React\Promise\Timer;
 use React\Promise\Timer\TimeoutException;
+use Exception;
+use UnderflowException;
 
 /**
  * Wait/sleep for `$time` seconds.
@@ -28,11 +29,17 @@ use React\Promise\Timer\TimeoutException;
  * really small (or negative) value, it will still start a timer and will thus
  * trigger at the earliest possible time in the future.
  *
+ * This function takes an optional `LoopInterface|null $loop` parameter that can be used to
+ * pass the event loop instance to use. You can use a `null` value here in order to
+ * use the [default loop](https://github.com/reactphp/event-loop#loop). This value
+ * SHOULD NOT be given unless you're sure you want to explicitly use a given event
+ * loop instance.
+ *
  * @param float $time
- * @param LoopInterface $loop
+ * @param ?LoopInterface $loop
  * @return void
  */
-function sleep($time, LoopInterface $loop)
+function sleep($time, LoopInterface $loop = null)
 {
     await(Timer\resolve($time, $loop), $loop);
 }
@@ -68,6 +75,12 @@ function sleep($time, LoopInterface $loop)
  *
  * See also the [examples](../examples/).
  *
+ * This function takes an optional `LoopInterface|null $loop` parameter that can be used to
+ * pass the event loop instance to use. You can use a `null` value here in order to
+ * use the [default loop](https://github.com/reactphp/event-loop#loop). This value
+ * SHOULD NOT be given unless you're sure you want to explicitly use a given event
+ * loop instance.
+ *
  * If no `$timeout` argument is given and the promise stays pending, then this
  * will potentially wait/block forever until the promise is settled. To avoid
  * this, API authors creating promises are expected to provide means to
@@ -80,18 +93,19 @@ function sleep($time, LoopInterface $loop)
  * start a timer and will thus trigger at the earliest possible time in the future.
  *
  * @param PromiseInterface $promise
- * @param LoopInterface    $loop
- * @param null|float       $timeout [deprecated] (optional) maximum timeout in seconds or null=wait forever
+ * @param ?LoopInterface   $loop
+ * @param ?float           $timeout [deprecated] (optional) maximum timeout in seconds or null=wait forever
  * @return mixed returns whatever the promise resolves to
  * @throws Exception when the promise is rejected
  * @throws TimeoutException if the $timeout is given and triggers
  */
-function await(PromiseInterface $promise, LoopInterface $loop, $timeout = null)
+function await(PromiseInterface $promise, LoopInterface $loop = null, $timeout = null)
 {
     $wait = true;
     $resolved = null;
     $exception = null;
     $rejected = false;
+    $loop = $loop ?: Loop::get();
 
     if ($timeout !== null) {
         $promise = Timer\timeout($promise, $timeout, $loop);
@@ -164,6 +178,12 @@ function await(PromiseInterface $promise, LoopInterface $loop, $timeout = null)
  * Once ALL promises reject, this function will fail and throw an `UnderflowException`.
  * Likewise, this will throw if an empty array of `$promises` is passed.
  *
+ * This function takes an optional `LoopInterface|null $loop` parameter that can be used to
+ * pass the event loop instance to use. You can use a `null` value here in order to
+ * use the [default loop](https://github.com/reactphp/event-loop#loop). This value
+ * SHOULD NOT be given unless you're sure you want to explicitly use a given event
+ * loop instance.
+ *
  * If no `$timeout` argument is given and ALL promises stay pending, then this
  * will potentially wait/block forever until the promise is fulfilled. To avoid
  * this, API authors creating promises are expected to provide means to
@@ -176,14 +196,14 @@ function await(PromiseInterface $promise, LoopInterface $loop, $timeout = null)
  * value, it will still start a timer and will thus trigger at the earliest
  * possible time in the future.
  *
- * @param array         $promises
- * @param LoopInterface $loop
- * @param null|float    $timeout [deprecated] (optional) maximum timeout in seconds or null=wait forever
+ * @param array          $promises
+ * @param ?LoopInterface $loop
+ * @param ?float         $timeout [deprecated] (optional) maximum timeout in seconds or null=wait forever
  * @return mixed returns whatever the first promise resolves to
  * @throws Exception if ALL promises are rejected
  * @throws TimeoutException if the $timeout is given and triggers
  */
-function awaitAny(array $promises, LoopInterface $loop, $timeout = null)
+function awaitAny(array $promises, LoopInterface $loop = null, $timeout = null)
 {
     // Explicitly overwrite argument with null value. This ensure that this
     // argument does not show up in the stack trace in PHP 7+ only.
@@ -249,6 +269,12 @@ function awaitAny(array $promises, LoopInterface $loop, $timeout = null)
  * and throw an `Exception`. If the promise did not reject with an `Exception`,
  * then this function will throw an `UnexpectedValueException` instead.
  *
+ * This function takes an optional `LoopInterface|null $loop` parameter that can be used to
+ * pass the event loop instance to use. You can use a `null` value here in order to
+ * use the [default loop](https://github.com/reactphp/event-loop#loop). This value
+ * SHOULD NOT be given unless you're sure you want to explicitly use a given event
+ * loop instance.
+ *
  * If no `$timeout` argument is given and ANY promises stay pending, then this
  * will potentially wait/block forever until the promise is fulfilled. To avoid
  * this, API authors creating promises are expected to provide means to
@@ -261,14 +287,14 @@ function awaitAny(array $promises, LoopInterface $loop, $timeout = null)
  * value, it will still start a timer and will thus trigger at the earliest
  * possible time in the future.
  *
- * @param array         $promises
- * @param LoopInterface $loop
- * @param null|float    $timeout [deprecated] (optional) maximum timeout in seconds or null=wait forever
+ * @param array          $promises
+ * @param ?LoopInterface $loop
+ * @param ?float         $timeout [deprecated] (optional) maximum timeout in seconds or null=wait forever
  * @return array returns an array with whatever each promise resolves to
  * @throws Exception when ANY promise is rejected
  * @throws TimeoutException if the $timeout is given and triggers
  */
-function awaitAll(array $promises, LoopInterface $loop, $timeout = null)
+function awaitAll(array $promises, LoopInterface $loop = null, $timeout = null)
 {
     // Explicitly overwrite argument with null value. This ensure that this
     // argument does not show up in the stack trace in PHP 7+ only.

--- a/tests/FunctionAwaitAllTest.php
+++ b/tests/FunctionAwaitAllTest.php
@@ -23,6 +23,13 @@ class FunctionAwaitAllTest extends TestCase
         $this->assertEquals(array('first' => 1, 'second' => 2), Block\awaitAll($all, $this->loop));
     }
 
+    public function testAwaitAllReturnsArrayWithFulfilledValueFromSinglePromiseWithoutGivingLoop()
+    {
+        $promise = Promise\resolve(42);
+
+        $this->assertEquals(array(42), Block\awaitAll(array($promise)));
+    }
+
     public function testAwaitAllRejected()
     {
         $all = array(

--- a/tests/FunctionAwaitAnyTest.php
+++ b/tests/FunctionAwaitAnyTest.php
@@ -26,6 +26,13 @@ class FunctionAwaitAnyTest extends TestCase
         $this->assertEquals(2, Block\awaitAny($all, $this->loop));
     }
 
+    public function testAwaitAnyReturnsFulfilledValueFromSinglePromiseWithoutGivingLoop()
+    {
+        $promise = Promise\resolve(42);
+
+        $this->assertEquals(42, Block\awaitAny(array($promise)));
+    }
+
     public function testAwaitAnyFirstResolvedConcurrently()
     {
         $d1 = new Deferred();

--- a/tests/FunctionAwaitTest.php
+++ b/tests/FunctionAwaitTest.php
@@ -58,6 +58,13 @@ class FunctionAwaitTest extends TestCase
         $this->assertEquals(2, Block\await($promise, $this->loop));
     }
 
+    public function testAwaitReturnsFulfilledValueWithoutGivingLoop()
+    {
+        $promise = Promise\resolve(42);
+
+        $this->assertEquals(42, Block\await($promise));
+    }
+
     public function testAwaitOneInterrupted()
     {
         $promise = $this->createPromiseResolved(2, 0.02);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace Clue\Tests\React\Block;
 
 use PHPUnit\Framework\TestCase as BaseTestCase;
+use React\EventLoop\Loop;
 use React\Promise\Deferred;
 
 class TestCase extends BaseTestCase
@@ -14,7 +15,7 @@ class TestCase extends BaseTestCase
      */
     public function setUpLoop()
     {
-        $this->loop = \React\EventLoop\Factory::create();
+        $this->loop = Loop::get();
     }
 
     protected function createPromiseResolved($value = null, $delay = 0.01)


### PR DESCRIPTION
This changeset simplifies usage by supporting the new [default loop](https://github.com/reactphp/event-loop#loop).

```php
// old (still supported)
Clue\React\Block\await($promise, $loop);
Clue\React\Block\awaitAny($promises, $loop);
Clue\React\Block\awaitAll($promises, $loop);

// new (using default loop)
Clue\React\Block\await($promise);
Clue\React\Block\awaitAny($promises);
Clue\React\Block\awaitAll($promises);
```

Builds on top of https://github.com/reactphp/event-loop/pull/226 and https://github.com/reactphp/http/pull/410
Builds on top of #59 